### PR TITLE
Detect non-IBM OpenJ9 builds properly

### DIFF
--- a/stf.core/src/stf.core/net/adoptopenjdk/stf/environment/JavaVersion.java
+++ b/stf.core/src/stf.core/net/adoptopenjdk/stf/environment/JavaVersion.java
@@ -223,7 +223,7 @@ public class JavaVersion {
 	}
 	
 	public boolean isIBMJvm() throws StfException {
-		return javaVersionOutput.contains("IBM");
+		return (javaVersionOutput.contains("IBM") | javaVersionOutput.contains("OpenJ9"));
 	}
 
 	public boolean isOracleJvm() throws StfException {


### PR DESCRIPTION
Tactical fix to allow OpenJ9 to be detected in the "isIBMJvm" check. Going forward we should look at changing this method either to rename it to isJ9vm or have separate ones to check for IBM and OpenJ9 if that is required. Would need going through all places it is used to figure out if anything is IBM specific.

Ref: https://github.com/eclipse/openj9-systemtest/issues/2