### PR TITLE
Allow automatic deletion of results files if the test passes.

### DIFF
--- a/stf.core/config/stf.properties
+++ b/stf.core/config/stf.properties
@@ -117,6 +117,9 @@ test-root = null
 # All result and debugging files are written below the following directory.
 results-root = ${STF_TEMP}
 
+# If true, remove the results directory if the test passed.
+rm-pass = false
+
 # The number of times that a plugins execute method is called.
 repeat=1
 

--- a/stf.core/src/stf.core/net/adoptopenjdk/stf/extensions/Stf.java
+++ b/stf.core/src/stf.core/net/adoptopenjdk/stf/extensions/Stf.java
@@ -34,6 +34,7 @@ public class Stf implements StfExtension {
 	public static Argument ARG_DEBUG_GENERATION                    = new Argument("stf", "debug-generation",                    true,  Required.OPTIONAL);
 	public static Argument ARG_JAVA_DEBUG_ARGS                     = new Argument("stf", "java-debug-args",                     false, Required.MANDATORY);
 	public static Argument ARG_CREATE_RESULTS_SYM_LINKS            = new Argument("stf", "create-results-sym-links",            true,  Required.MANDATORY);
+	public static Argument ARG_RM_PASS                             = new Argument("stf", "rm-pass",                             true,  Required.OPTIONAL);
 	// For perl and java
 	public static Argument ARG_HELP                                = new Argument("stf", "help",                                true,  Required.OPTIONAL);
 	public static Argument ARG_LIST_TESTS                          = new Argument("stf", "list",                                true,  Required.OPTIONAL);	
@@ -71,6 +72,7 @@ public class Stf implements StfExtension {
 			ARG_DEBUG_GENERATION,
 			ARG_JAVA_DEBUG_ARGS,
 			ARG_CREATE_RESULTS_SYM_LINKS,
+			ARG_RM_PASS,
 			ARG_TEST_ROOT,
 			ARG_HELP,
 			ARG_LIST_TESTS,
@@ -209,6 +211,10 @@ public class Stf implements StfExtension {
 				+ "always be at the same location.\n"
 				+ "Only supported on systems which support symbolic links.\n"
 				+ "Disabled by default to prevent.");
+		
+		help.outputArgName("-" + ARG_RM_PASS.getName());
+		help.outputArgDesc("If set to true (or just passed as a flag) then stf.pl deletes the results directory if the test passes."
+				+ "Disabled by default.");
 	}
 
 	@Override


### PR DESCRIPTION
If the test runs and passes then the default behaviour is to retain
the results files for the last 10 tests. If the first test fails, but
the next 10 pass, then the failed test's results will be deleted.

This functionality allows the user to prevent that by deleting the
results from passing tests.

Signed-off-by: Adam Farley <adam.farley@uk.ibm.com>