### PR TITLE
Allow users to pass arguments to the stf perl layer

### DIFF
--- a/stf.build/makefile
+++ b/stf.build/makefile
@@ -259,7 +259,7 @@ ifneq (,$(JAVA_ARGS))
   JAVA_ARGS_ARG:=-java-args="$(subst ",$(ESC_DQ),$(JAVA_ARGS))"
 endif
 
-STF_COMMAND:=perl $(TARGET_ROOT)$(D)stf.core$(D)scripts$(D)stf.pl $(JAVA_ARGS_ARG) -systemtest-prereqs=$(PREREQS_ROOT)
+STF_COMMAND:=perl $(TARGET_ROOT)$(D)stf.core$(D)scripts$(D)stf.pl $(JAVA_ARGS_ARG) -systemtest-prereqs=$(PREREQS_ROOT) $(STF_ARGS)
 
 # Targets to run the samples
 SAMPLE_TARGETS:=test.list \

--- a/stf.build/makefile
+++ b/stf.build/makefile
@@ -259,7 +259,11 @@ ifneq (,$(JAVA_ARGS))
   JAVA_ARGS_ARG:=-java-args="$(subst ",$(ESC_DQ),$(JAVA_ARGS))"
 endif
 
-STF_COMMAND:=perl $(TARGET_ROOT)$(D)stf.core$(D)scripts$(D)stf.pl $(JAVA_ARGS_ARG) -systemtest-prereqs=$(PREREQS_ROOT) $(STF_ARGS)
+ifeq ($(RM_PASS),1)
+    RM_PASS_ARG:=-rm-pass
+endif
+
+STF_COMMAND:=perl $(TARGET_ROOT)$(D)stf.core$(D)scripts$(D)stf.pl $(JAVA_ARGS_ARG) -systemtest-prereqs=$(PREREQS_ROOT) $(RM_PASS_ARG)
 
 # Targets to run the samples
 SAMPLE_TARGETS:=test.list \


### PR DESCRIPTION
If the user wants to use stf.pl options that we don't anticipate in
the makefile, this option allows them to do that. This prevents code
duplication and dependencies between the make and perl code.

Signed-off-by: Adam Farley <adam.farley@uk.ibm.com>