### PR TITLE
Externalise option to store more in results_root

### DIFF
--- a/stf.core/config/stf.properties
+++ b/stf.core/config/stf.properties
@@ -117,6 +117,14 @@ test-root = null
 # All result and debugging files are written below the following directory.
 results-root = ${STF_TEMP}
 
+# Set default number of directories to retain under results-root. stf.pl
+# will use an LRU algorithm but retain failed tests
+retain = 10
+
+# Set default number of directories under results-root that will be taken to
+# indicate "We have suffered a very bad failure". This should be > retain above
+retain-limit = 20
+
 # If true, remove the results directory if the test passed.
 rm-pass = false
 

--- a/stf.core/scripts/stf.pl
+++ b/stf.core/scripts/stf.pl
@@ -162,7 +162,9 @@ if ($test_list_arg ne 'false') {
 my $timestamp = sprintf '%04d%02d%02d-%02d%02d%02d', $year+1900, $mon+1, $mday, $hour, $min, $sec;
 
 # Work out where the working, temp and results directories are going
-my $results_root = stfArguments::get_and_check_argument("results-root");
+my $results_root  = stfArguments::get_and_check_argument("results-root");
+my $retain_number = stfArguments::get_and_check_argument("retain");
+my $retain_limit  = stfArguments::get_and_check_argument("retain-limit");
 my $test_dir = $results_root . "/$timestamp-$test_name";
 my $debug_dir   = $test_dir . "/debug";
 my $results_dir = $test_dir . "/results";
@@ -170,12 +172,31 @@ my $generation_dir = $test_dir . "/generation";
 my $setup_dir      = $test_dir . "/setUp";
 my $execute_dir    = $test_dir . "/execute";
 my $teardown_dir   = $test_dir . "/tearDown";
+my $delete_results_root = $FALSE;
 
 my @results_dirs;
 
+if ( length $retain_limit ) {
+   $results_retention_limit = $retain_limit;
+}
+
+if ( length $retain_number ) {
+   if ( $retain_number == 0 ) {
+     # Nothing we run should produce this much ...
+     $results_retention_number = 1000000;
+   } else {
+     $results_retention_number = $retain_number;
+   }
+   # Increase results_retention_limit in line, otherwise failures are likely
+   # User can override this with the retain-limit option if the wish to
+   if ( $results_retention_number > $results_retention_limit ) {
+      print "WARNING: Overriding retain-limit to retain + 1\n";
+      $results_retention_limit = $results_retention_number+1;
+   }
+}
+
 # We are only going to remove results_root if it passes some basic checks.
 # So check its structure to verify it contains STF artifacts.
-my $delete_results_root = $FALSE;
 if (-e $results_root) {
 	my @files = <'$results_root/*'>;
 	my $count = @files;

--- a/stf.core/scripts/stf.pl
+++ b/stf.core/scripts/stf.pl
@@ -142,6 +142,10 @@ if (stfArguments::get_argument("help") ne 'false') {
     if ($test_name eq 'null') {
         print "To get STF help please run again with a '-test' argument.\n";
         print "This will allow STF to produce help on the extensions used by that test case.\n";
+        print "Extra options specific to this perl script.\n";
+        print "   -retain=nnn        Set the number of output directories to keep.\n";
+        print "   -retain-limit=nnn  Set the maximum number of failed output\n";
+        print "                      directories before a failure condition is declared\n";
         exit 0;
     }
 }

--- a/stf.core/scripts/stf.pl
+++ b/stf.core/scripts/stf.pl
@@ -181,12 +181,7 @@ if ( length $retain_limit ) {
 }
 
 if ( length $retain_number ) {
-   if ( $retain_number == 0 ) {
-     # Nothing we run should produce this much ...
-     $results_retention_number = 1000000;
-   } else {
-     $results_retention_number = $retain_number;
-   }
+   $results_retention_number = $retain_number;
    # Increase results_retention_limit in line, otherwise failures are likely
    # User can override this with the retain-limit option if the wish to
    if ( $results_retention_number > $results_retention_limit ) {

--- a/stf.core/src/stf.core/net/adoptopenjdk/stf/extensions/Stf.java
+++ b/stf.core/src/stf.core/net/adoptopenjdk/stf/extensions/Stf.java
@@ -63,8 +63,9 @@ public class Stf implements StfExtension {
 	public static Argument ARG_JAVA_ARGS_EXECUTE_SECONDARY         = new Argument("stf", "java-args-execute-secondary",         false, Required.OPTIONAL);
 	public static Argument ARG_JAVA_ARGS_EXECUTE_SECONDARY_COMMENT = new Argument("stf", "java-args-execute-secondary-comment", false, Required.OPTIONAL);
 	public static Argument ARG_JAVA_ARGS_TEARDOWN                  = new Argument("stf", "java-args-teardown",                  false, Required.OPTIONAL);
-	// Stf doesn't use these but since the perl layuer requires defaults
-	// in the properties file they get set, so need to allow them
+	// Stf doesn't use these but since the perl layer requires defaults
+	// in the properties file they get set, so need to tolerate them
+	// To avoid confusion these aren't listed in the help output
 	public static Argument ARG_RETAIN                              = new Argument("stf", "retain",                              false, Required.OPTIONAL);
 	public static Argument ARG_RETAIN_LIMIT                        = new Argument("stf", "retain-limit",                        false, Required.OPTIONAL);
 	

--- a/stf.core/src/stf.core/net/adoptopenjdk/stf/extensions/Stf.java
+++ b/stf.core/src/stf.core/net/adoptopenjdk/stf/extensions/Stf.java
@@ -43,7 +43,7 @@ public class Stf implements StfExtension {
 	public static Argument ARG_TEST_ROOT                           = new Argument("stf", "test-root",                           false, Required.OPTIONAL);
 	public static Argument ARG_TEST_ARGS                           = new Argument("stf", "test-args",                           false, Required.OPTIONAL);
 	public static Argument ARG_STF_BIN_DIR                         = new Argument("stf", "stf-bin-dir",                         false, Required.OPTIONAL);
-	public static Argument ARG_SYSTEMTEST_PREREQS                     = new Argument("stf", "systemtest-prereqs",                     false, Required.MANDATORY);
+	public static Argument ARG_SYSTEMTEST_PREREQS                  = new Argument("stf", "systemtest-prereqs",                     false, Required.MANDATORY);
 	public static Argument ARG_REPEAT_COUNT                        = new Argument("stf", "repeat",                              false, Required.OPTIONAL);
 	public static Argument ARG_VERBOSE                             = new Argument("stf", "v",                                   true,  Required.OPTIONAL);	
 	public static Argument ARG_VERBOSE_VERBOSE                     = new Argument("stf", "vv",                                  true,  Required.OPTIONAL);	
@@ -63,7 +63,10 @@ public class Stf implements StfExtension {
 	public static Argument ARG_JAVA_ARGS_EXECUTE_SECONDARY         = new Argument("stf", "java-args-execute-secondary",         false, Required.OPTIONAL);
 	public static Argument ARG_JAVA_ARGS_EXECUTE_SECONDARY_COMMENT = new Argument("stf", "java-args-execute-secondary-comment", false, Required.OPTIONAL);
 	public static Argument ARG_JAVA_ARGS_TEARDOWN                  = new Argument("stf", "java-args-teardown",                  false, Required.OPTIONAL);
-
+	// Stf doesn't use these but since the perl layuer requires defaults
+	// in the properties file they get set, so need to allow them
+	public static Argument ARG_RETAIN                              = new Argument("stf", "retain",                              false, Required.OPTIONAL);
+	public static Argument ARG_RETAIN_LIMIT                        = new Argument("stf", "retain-limit",                        false, Required.OPTIONAL);
 	
 	@Override
 	public Argument[] getSupportedArguments() {
@@ -98,7 +101,9 @@ public class Stf implements StfExtension {
 			ARG_JAVA_ARGS_EXECUTE_SECONDARY_INITIAL,
 			ARG_JAVA_ARGS_EXECUTE_SECONDARY,
 			ARG_JAVA_ARGS_EXECUTE_SECONDARY_COMMENT,
-			ARG_JAVA_ARGS_TEARDOWN
+			ARG_JAVA_ARGS_TEARDOWN,
+			ARG_RETAIN,
+			ARG_RETAIN_LIMIT
 		};
 	}
 


### PR DESCRIPTION
Needed to retain the full set of results when the JCK is executed via STF. Ref: https://github.com/AdoptOpenJDK/stf/issues/22