### PR TITLE
Add macosx to getOsgiOperatingSystemName()

### DIFF
--- a/stf.core/src/stf.core/net/adoptopenjdk/stf/environment/StfEnvironmentCore.java
+++ b/stf.core/src/stf.core/net/adoptopenjdk/stf/environment/StfEnvironmentCore.java
@@ -402,7 +402,7 @@ public class StfEnvironmentCore {
 	
 	/** 
 	 * Returns the osgi.os name.
-	 * Expected return values are win32, linux, aix, zos
+	 * Expected return values are win32, linux, aix, zos, macosx
 	 */
 	public String getOsgiOperatingSystemName() throws StfException {
 		switch (PlatformFinder.getPlatform()) {
@@ -410,6 +410,7 @@ public class StfEnvironmentCore {
 		case AIX :    return "aix";
 		case LINUX:   return "linux";
 		case ZOS :    return "zos";
+		case OSX :    return "macosx";
 		default:      throw new StfException("Unknown platform for osgi.os: " + PlatformFinder.getPlatformAsString());
 		}
 	}

--- a/stf.core/src/stf.core/net/adoptopenjdk/stf/extensions/core/StfEnvironment.java
+++ b/stf.core/src/stf.core/net/adoptopenjdk/stf/extensions/core/StfEnvironment.java
@@ -183,7 +183,7 @@ public class StfEnvironment {
 
 	/** 
 	 * Returns the osgi.os name.
-	 * Expected return values are win32, linux, aix
+	 * Expected return values are win32, linux, aix, macosx
 	 */
 	public String getOsgiOperatingSystemName() throws StfException {
 		return environmentCore.getOsgiOperatingSystemName();


### PR DESCRIPTION
Along with a PR to the openjdk_systemtest repo fixes https://github.com/AdoptOpenJDK/stf/issues/20