### PR TITLE
Remove initialisation warnings in stf.pl

### DIFF
--- a/stf.core/scripts/stf.pl
+++ b/stf.core/scripts/stf.pl
@@ -571,14 +571,14 @@ sub output_banner {
     }
     
     # Create highlight string, with repeating '=' characters
-    my $highlight;
+    my $highlight="";
     my $i;
     for ($i=0; $i<$numHighlight; $i++) {
         $highlight = $highlight . "=";
     }
        
-	# Format the banner text. Capitalise and add spacing    
-    my $formattedBannerText;
+    # Format the banner text. Capitalise and add spacing    
+    my $formattedBannerText="";
     for ($i=0; $i<length $bannerText; $i++) {
         $formattedBannerText = $formattedBannerText . uc substr($bannerText, $i, 1);
         if ($i != (length $bannerText) -1) {


### PR DESCRIPTION
Not quite sure why but I had an issue when running on my windows machine where perl was complaining about a couple of uninitialised variables when I ran it directly from the command line. This fixes those errors.