### PR TITLE
Add switch to turn off dump generation after first failure in load test

### DIFF
--- a/stf.core/src/stf.core/net/adoptopenjdk/stf/processes/definitions/LoadTestProcessDefinition.java
+++ b/stf.core/src/stf.core/net/adoptopenjdk/stf/processes/definitions/LoadTestProcessDefinition.java
@@ -287,6 +287,20 @@ public class LoadTestProcessDefinition implements ProcessDefinition {
 	}
 	
 	/**
+	 * Optional method which sets the flag to trigger core dumps to be generated after first failure
+	 * is detected in a load test run.
+	 * @param dumpRequested can be set to true (default is false) to trigger dump generation 
+	 * @return Updated load test process definition.
+	 */
+	public LoadTestProcessDefinition generateCoreDumpAtFirstLoadTestFailure(boolean dumpRequested) throws StfException {
+		checkAndUpdateLevel(Stage.LOAD_TEST_ARGS);
+		
+		javaProcessDefinition.addArg("-dumpRequested", Boolean.toString(dumpRequested));
+		
+		return this;
+	}
+	
+	/**
 	 * Optional method which controls how many test failures are reported in detail, with 
 	 * a description of the failing test case and a stack trace, etc.
 	 * Once the reporting limit is reached load test prints out a single line to say that a failure

--- a/stf.load/src/stf.load/net/adoptopenjdk/loadTest/FirstFailureDumper.java
+++ b/stf.load/src/stf.load/net/adoptopenjdk/loadTest/FirstFailureDumper.java
@@ -108,19 +108,23 @@ public class FirstFailureDumper {
      * It should be called when load test has its first failure.
      * @throws StfException if a dump method could not be called.
      */
-    public synchronized void createDumpIfFirstFailure(LoadTestBase test) {
+    public synchronized void createDumpIfFirstFailure(LoadTestBase test, boolean dumpRequested) {
         if (haveCreatedFirstFailureDumps) { 
         	return;
         }
 		
-        if (isJ9) {
+        if (isJ9 && dumpRequested) {
 			logger.info("First failure detected by thread: " + Thread.currentThread().getName() + ". Running test: " + test.toString() + ". Creating java dumps.");
 			createDump("heap", heapDumpMethod, HEAPDUMP_FILE_NAME);
 			createDump("java", javaDumpMethod, JAVADUMP_FILE_NAME);
 			createDump("system", systemDumpMethod, SYSTEMDUMP_FILE_NAME);
 			
 		} else {
-			logger.info("First failure detected by thread: " + Thread.currentThread().getName() + ". Not creating dumps as not running on an IBM JVM");
+			if (!dumpRequested) {
+				logger.info("First failure detected by thread: " + Thread.currentThread().getName() + ". Not creating dumps as no dump generation is requested for this load test");
+			} else { 
+				logger.info("First failure detected by thread: " + Thread.currentThread().getName() + ". Not creating dumps as not running on an IBM JVM");
+			}
 		}
 		
 		haveCreatedFirstFailureDumps = true;

--- a/stf.load/src/stf.load/net/adoptopenjdk/loadTest/InventoryData.java
+++ b/stf.load/src/stf.load/net/adoptopenjdk/loadTest/InventoryData.java
@@ -68,7 +68,8 @@ public class InventoryData {
 	// Lower values potentially use less memory, but will sometimes mean that the exact weightings
 	// cannot be honoured.
 	private static int MAX_WEIGHTING_LOOKUP_SIZE = 500000;
-	
+
+	private static boolean dumpRequested = false; 
 	
 	/**
 	 * Parse an XML test 'inventory' file (which lists the tests to be run for the
@@ -85,11 +86,12 @@ public class InventoryData {
 	 * The exclusion files are also specified as paths below the root directory.
 	 * @param verbose should be set to true for debug level progress reporting.
 	 */
-	InventoryData(ArrayList<DirectoryRef> testRoots, String inventoryFileRef, ArrayList<String> exclusionFiles, boolean countingOnly, boolean verbose) throws Exception {
+	InventoryData(ArrayList<DirectoryRef> testRoots, String inventoryFileRef, ArrayList<String> exclusionFiles, boolean countingOnly, boolean verbose, boolean dumpRequested) throws Exception {
 		this.inventoryFileRef = inventoryFileRef;
 		this.countingOnly = countingOnly;
 		this.verbose = verbose;
-
+		this.dumpRequested = dumpRequested; 
+		
 		// Read the inventory file and any which it includes
 		testList = readInventoryFile(testRoots, inventoryFileRef);
 		
@@ -169,7 +171,7 @@ public class InventoryData {
 					String mauveFullClassname = testNode.getAttributes().getNamedItem("class").getNodeValue();
 					BigDecimal weighting = parseWeighting(testNode, inventoryFileRef, nodeNumber);
 					
-					AdaptorInterface testcase = new MauveAdaptor(nextTestNum, mauveFullClassname, weighting);
+					AdaptorInterface testcase = new MauveAdaptor(nextTestNum, mauveFullClassname, weighting, dumpRequested);
 					tests.add(testcase);
 					nextTestNum++;
 						
@@ -187,7 +189,7 @@ public class InventoryData {
 					ArrayList<String> constructorArgs = parseArgumentList(testNode, "constructorArguments");
 					ArrayList<String> methodArgs = parseArgumentList(testNode, "methodArguments");
 					
-					AdaptorInterface testcase = new ArbitraryJavaAdaptor(nextTestNum, classname, constructorArgs, methodName, methodArgs, weighting, countingOnly);
+					AdaptorInterface testcase = new ArbitraryJavaAdaptor(nextTestNum, classname, constructorArgs, methodName, methodArgs, weighting, countingOnly, dumpRequested);
 					tests.add(testcase);
 					nextTestNum++;
 
@@ -201,7 +203,7 @@ public class InventoryData {
 					String junitClassName = testNode.getAttributes().getNamedItem("class").getNodeValue();
 					BigDecimal weighting = parseWeighting(testNode, inventoryFileRef, nodeNumber);
 					
-					AdaptorInterface testcase = new JUnitAdaptor(nextTestNum, junitClassName, weighting);
+					AdaptorInterface testcase = new JUnitAdaptor(nextTestNum, junitClassName, weighting, dumpRequested);
 					tests.add(testcase);
 					nextTestNum++;
 
@@ -335,7 +337,7 @@ public class InventoryData {
 		try {
 			ArrayList<String> exclusionFiles = LoadTestProcessDefinition.findExclusionFiles(testRoots, inventoryFileRef);
 			
-			InventoryData inventory = new InventoryData(testRoots, inventoryFileRef, exclusionFiles, true, false);
+			InventoryData inventory = new InventoryData(testRoots, inventoryFileRef, exclusionFiles, true, false, dumpRequested);
 			return inventory.getNumberOfTests();
 		} catch (Exception e) {
 			throw new StfException("Failed to parse inventory file", e);

--- a/stf.load/src/stf.load/net/adoptopenjdk/loadTest/LoadTest.java
+++ b/stf.load/src/stf.load/net/adoptopenjdk/loadTest/LoadTest.java
@@ -60,6 +60,9 @@ public class LoadTest {
 	// LoadTest behaviour on OMM controllable through argument
 	private boolean abortIfOutOfMemory = true; 
 	
+	// This flag indicates whether or not to create core dumps on the event of first load test failure 
+	private boolean dumpRequested = false; 
+	
 	// Error reporting control
 	private int reportFailureLimit = 10; 
 	private int abortAtFailureLimit = 25;
@@ -151,7 +154,7 @@ public class LoadTest {
 				abortIfOutOfMemory,
 				reportFailureLimit, abortAtFailureLimit,
 				maxTotalLogFileSpace, maxSingleLogSize,
-				suites);
+				suites, dumpRequested);
 		return loadTestRunner.run();
 	}
 
@@ -193,6 +196,10 @@ public class LoadTest {
 			} else if (argName.equals("-abortIfOutOfMemory")) {
 				String abortValue = getArgValue(args, i++);
 				this.abortIfOutOfMemory = Boolean.parseBoolean(abortValue);
+			
+			} else if (argName.equals("-dumpRequested")) {
+				String dumpReq = getArgValue(args, i++);
+				this.dumpRequested = Boolean.parseBoolean(dumpReq);
 				
 			} else if (argName.equals("-reportFailureLimit")) {
 				this.reportFailureLimit = Integer.parseInt(getArgValue(args, i++));
@@ -458,7 +465,7 @@ public class LoadTest {
 		// (workspace root and test root).
 		ArrayList<DirectoryRef> inventoryRootArray = new ArrayList<DirectoryRef>();
 		inventoryRootArray.add(inventoryRoot);
-		InventoryData inventory = new InventoryData(inventoryRootArray, inventoryFileOffset, excludeFiles, false, true);
+		InventoryData inventory = new InventoryData(inventoryRootArray, inventoryFileOffset, excludeFiles, false, true, dumpRequested);
 
 		return new SuiteData(suiteNum, numThreads, seed, inventory, numberTests, repeatCount, minThinkingTime, maxThinkingTime, selection);
 	}

--- a/stf.load/src/stf.load/net/adoptopenjdk/loadTest/LoadTestRunner.java
+++ b/stf.load/src/stf.load/net/adoptopenjdk/loadTest/LoadTestRunner.java
@@ -59,13 +59,15 @@ class LoadTestRunner {
 	private final int maxSingleLogSize;
 	private final ArrayList<SuiteData> suites;
 	private final long reportingFrequency;
+	private boolean dumpRequested; 
 
 	
 	LoadTestRunner(File resultsDir, String resultsPrefix, boolean timeLimitedTest, long testEndTime, 
 				boolean abortIfOutOfMemory,
 				int reportFailureLimit, int abortAtFailureLimit,
 				long maxTotalLogFileSpace, int maxSingleLogSize,
-				ArrayList<SuiteData> suites) {
+				ArrayList<SuiteData> suites,
+				boolean dumpRequested) {
 		this.resultsDir = resultsDir;
 		this.resultsPrefix = resultsPrefix;
 		this.timeLimitedTest = timeLimitedTest;
@@ -76,6 +78,7 @@ class LoadTestRunner {
 		this.maxTotalLogFileSpace = maxTotalLogFileSpace;
 		this.maxSingleLogSize = maxSingleLogSize;
 		this.suites = suites;
+		this.dumpRequested = dumpRequested; 
 		
 		// Decide how frequency progress reports are to be made
 		String reportingFrequencyString = System.getenv(REPORTING_FREQUENCY_ENV_NAME);
@@ -197,9 +200,13 @@ class LoadTestRunner {
 								if (testPassed) {
 									numberPassingTests.incrementAndGet();
 								} else {
-									// Produce java dumps for only the first test failure 
+									// Produce java dumps for only the first test failure if flag for creating dump is set by user
 									long failureNum = numberFailingTests.incrementAndGet();
-									FirstFailureDumper.instance().createDumpIfFirstFailure((LoadTestBase) test);
+									
+									logger.info("suite.getInventory().getInventoryFileRef(): " + suite.getInventory().getInventoryFileRef());
+									logger.info("suite.isCreateDump() : " + dumpRequested);
+									
+									FirstFailureDumper.instance().createDumpIfFirstFailure((LoadTestBase) test, dumpRequested);
 									
 									// Get log4j to report the test failure
 									reportFailure(failureNum, executionTracker.getCapturedOutput(), test, suite, threadNum);
@@ -229,7 +236,8 @@ class LoadTestRunner {
 
 								// Produce java dumps if this is the first test error
 								long failureNum = numberFailingTests.incrementAndGet();
-								FirstFailureDumper.instance().createDumpIfFirstFailure((LoadTestBase) test);
+								
+								FirstFailureDumper.instance().createDumpIfFirstFailure((LoadTestBase) test, dumpRequested);
 								
 								// Report exception to process output
 								reportFailure(failureNum, executionTracker.getCapturedOutput(), test, suite, threadNum);

--- a/stf.load/src/stf.load/net/adoptopenjdk/loadTest/SuiteData.java
+++ b/stf.load/src/stf.load/net/adoptopenjdk/loadTest/SuiteData.java
@@ -119,7 +119,6 @@ public class SuiteData {
 		return maxThinkingTime;
 	}
 
-
 	/**
 	 * @return The next test to run, or null if it's time to finish load testing.
 	 */

--- a/stf.load/src/stf.load/net/adoptopenjdk/loadTest/adaptors/ArbitraryJavaAdaptor.java
+++ b/stf.load/src/stf.load/net/adoptopenjdk/loadTest/adaptors/ArbitraryJavaAdaptor.java
@@ -36,10 +36,10 @@ public class ArbitraryJavaAdaptor extends LoadTestBase {
 	private Object[] constructorArgs;
 	private Method javaMethod;
 	private Object[] methodArgs;
-	
+	private boolean dumpRequested; 
 	
 	public ArbitraryJavaAdaptor(int testNum, String testClassName, ArrayList<String> constructorArgValues, 
-					String testMethodName, ArrayList<String> methodArgValues, BigDecimal weighting, boolean countingOnly) 
+					String testMethodName, ArrayList<String> methodArgValues, BigDecimal weighting, boolean countingOnly, boolean dumpRequired) 
 				throws ClassNotFoundException, NoSuchMethodException, SecurityException, StfException {
 		super(testNum, testClassName, testMethodName, weighting);
 
@@ -51,7 +51,8 @@ public class ArbitraryJavaAdaptor extends LoadTestBase {
 		
 		this.testClassName = testClassName;
 		this.testMethodName = testMethodName;
-
+		this.dumpRequested = dumpRequired; 
+		
 		javaClass = Class.forName(testClassName);
 		
 		// Find a constructor which is compatible with the supplied constructor arguments
@@ -101,11 +102,11 @@ public class ArbitraryJavaAdaptor extends LoadTestBase {
 			javaMethod.invoke(instance, methodArgs);
 		} catch (InvocationTargetException e) {
 			// Test will be marked as a failure
-			FirstFailureDumper.instance().createDumpIfFirstFailure(this);
+			FirstFailureDumper.instance().createDumpIfFirstFailure(this, dumpRequested);
 			throw e.getCause();
 		} catch (Throwable t) {
 			// Test will be marked as a failure
-			FirstFailureDumper.instance().createDumpIfFirstFailure(this);
+			FirstFailureDumper.instance().createDumpIfFirstFailure(this, dumpRequested);
 			throw t;
 		}
 		

--- a/stf.load/src/stf.load/net/adoptopenjdk/loadTest/adaptors/JUnitAdaptor.java
+++ b/stf.load/src/stf.load/net/adoptopenjdk/loadTest/adaptors/JUnitAdaptor.java
@@ -33,12 +33,13 @@ import net.adoptopenjdk.stf.environment.PlatformFinder;
  */
 public class JUnitAdaptor extends LoadTestBase {
 	private final String testClass;
+	private boolean dumpRequested; 
 
-
-	public JUnitAdaptor(int testNum, String testClass, BigDecimal weighting) {
+	public JUnitAdaptor(int testNum, String testClass, BigDecimal weighting, boolean dumpRequested) {
 		super(testNum, testClass, null, weighting);
 		
 		this.testClass = testClass;
+		this.dumpRequested = dumpRequested; 
 	}
 
 
@@ -81,7 +82,7 @@ public class JUnitAdaptor extends LoadTestBase {
         		}
         	}
         	public void testFailure(Failure failure) throws Exception {
-        		FirstFailureDumper.instance().createDumpIfFirstFailure(test);
+        		FirstFailureDumper.instance().createDumpIfFirstFailure(test, dumpRequested);
         		reportProgress("testFailure: " + failure);
         		failures.add(failure.getException());
         		failure.getException().printStackTrace(System.out);
@@ -89,7 +90,7 @@ public class JUnitAdaptor extends LoadTestBase {
        			awaitingResult = false;
         	}
 			public void testAssumptionFailure(Failure failure) {
-				FirstFailureDumper.instance().createDumpIfFirstFailure(test);
+        		FirstFailureDumper.instance().createDumpIfFirstFailure(test, dumpRequested);
 				reportProgress("testAssumptionFailure: " + failure);
         		failures.add(failure.getException());
        			addResult("fail", platform, failure.getDescription(), failure.getMessage(), failure.getException());

--- a/stf.load/src/stf.load/net/adoptopenjdk/loadTest/adaptors/MauveAdaptor.java
+++ b/stf.load/src/stf.load/net/adoptopenjdk/loadTest/adaptors/MauveAdaptor.java
@@ -30,12 +30,13 @@ public class MauveAdaptor extends LoadTestBase {
 	// if a Mauve test has passed or failed
 	private static byte[] PASS_INDICATOR = "PASS:".getBytes();
 	private static byte[] FAIL_INDICATOR = "FAIL:".getBytes();
-	
+	boolean dumpRequested; 
 
-	public MauveAdaptor(int testNum, String fullClassname, BigDecimal weighting) {
+	public MauveAdaptor(int testNum, String fullClassname, BigDecimal weighting, boolean dumpRequired) {
 		super(testNum, fullClassname, null, weighting);
 		
 		this.fullMauveClass = fullClassname;
+		this.dumpRequested = dumpRequired; 
 	}
 
 
@@ -95,7 +96,7 @@ public class MauveAdaptor extends LoadTestBase {
 		if (startsWith(output, off, len, PASS_INDICATOR)) {
 			resultStatus = ResultStatus.PASS;
 		} else if (startsWith(output, off, len, FAIL_INDICATOR)) {
-			FirstFailureDumper.instance().createDumpIfFirstFailure(this);
+			FirstFailureDumper.instance().createDumpIfFirstFailure(this, dumpRequested);
 			resultStatus = ResultStatus.FAIL;
 		}
 		


### PR DESCRIPTION
Resolves  https://github.com/AdoptOpenJDK/stf/issues/51
Signed-off-by: Mesbah_Alam@ca.ibm.com <Mesbah_Alam@ca.ibm.com>