### PR TITLE
Add helper method to check if a Java argument exists

### DIFF
--- a/stf.core/src/stf.core/net/adoptopenjdk/stf/extensions/core/StfCoreExtension.java
+++ b/stf.core/src/stf.core/net/adoptopenjdk/stf/extensions/core/StfCoreExtension.java
@@ -1459,6 +1459,24 @@ public class StfCoreExtension implements StfExtension {
 					+ "Actual Java arguments for this stage are \"" + convertToString(actualArgs) + "\"");
 		}
 	}
+	
+	
+	/**
+	 * Checks if that java processes using the primary JVM contains the given JVM option
+	 * 
+	 * @param stage is the stage whose arguments should be checked.
+	 * @param argToCheck contains 1 java arguments.
+	 */
+	public boolean isJavaArgPresent(Stage stage, String argToCheck) throws StfException {
+		if (stage == Stage.INITIALISATION) {
+			throw new StfException("Java argument verification is not valid for the initialisation stage.");
+		}
+
+		// Get hold of the mandatory and actual java arguments
+		ArrayList<String> actualArgs = getActiveJavaArgs(stage);
+		Set<String> actualArgsSet = new LinkedHashSet<String>(actualArgs);
+		return actualArgsSet.contains(argToCheck);
+	}
 
 
 	/**


### PR DESCRIPTION
This PR adds a helper method that checks if a given set of Java arguments are present in the list of test arguments. This is used in the tests where we need to check if specific special JIT options (e.g. -Xjit:count=0, etc) are being used

Related to : https://github.com/AdoptOpenJDK/openjdk-systemtest/issues/292 
 
Signed-off-by: Mesbah_Alam@ca.ibm.com <Mesbah_Alam@ca.ibm.com>