### PR TITLE
Accept 32 as bit value for zOS and zLinux 

### DIFF
--- a/stf.core/src/stf.core/net/adoptopenjdk/stf/environment/PlatformFinder.java
+++ b/stf.core/src/stf.core/net/adoptopenjdk/stf/environment/PlatformFinder.java
@@ -229,20 +229,12 @@ public class PlatformFinder {
 
     private static String calcArchType() {
         // get the architecture name and the architecture type (32, 64)
-        // change 32 to 31 if we are on 390
         String osArchType = System.getProperty("sun.arch.data.model");
         String osArch = System.getProperty("os.arch");
            
         // if no Sun classes, use IBM one instead
         if (osArchType == null) {
             osArchType = System.getProperty("com.ibm.vm.bitmode");
-        }
-        
-        // if the current system is a 390 machine use 390 as the osArch    	 
-        if (((osArch.length() >= 4 && osArch.substring(0, 4).equals("s390")) || 
-             (osArch.length() >= 3 && osArch.substring(0, 3).equals("390"))) && 
-             (osArchType.equals("32"))) {
-         osArchType = "31";    		 
         }
         
         return osArchType;


### PR DESCRIPTION
Remove the logic of replacing "31" with "32" for the bit value when we are on zLinux or zOS 31 bit platform.  
Background: backlog/issues/307
FYI @lumpfish 
Signed-off-by: Mesbah_Alam@ca.ibm.com <Mesbah_Alam@ca.ibm.com>