### PR TITLE
Throw exception when Mauve tests fail so it can be used in -Xdump

### DIFF
--- a/stf.load/src/stf.load/net/adoptopenjdk/loadTest/LoadTestRunner.java
+++ b/stf.load/src/stf.load/net/adoptopenjdk/loadTest/LoadTestRunner.java
@@ -211,7 +211,11 @@ class LoadTestRunner {
 									FirstFailureDumper.instance().createDumpIfFirstFailure((LoadTestBase) test, dumpRequested);
 									
 									// Get log4j to report the test failure
-									reportFailure(failureNum, executionTracker.getCapturedOutput(), test, suite, threadNum);
+									try {
+										reportFailure(failureNum, executionTracker.getCapturedOutput(), test, suite, threadNum);
+									} catch (MauveTestFailureException e) {
+										throw e;
+									}
 								}
 								
 								// Inter test thinking time
@@ -242,7 +246,11 @@ class LoadTestRunner {
 								FirstFailureDumper.instance().createDumpIfFirstFailure((LoadTestBase) test, dumpRequested);
 								
 								// Report exception to process output
-								reportFailure(failureNum, executionTracker.getCapturedOutput(), test, suite, threadNum);
+								try { 
+									reportFailure(failureNum, executionTracker.getCapturedOutput(), test, suite, threadNum);
+								} catch (MauveTestFailureException e) {
+									e.printStackTrace();
+								}
 								
 								// Out of memory exceptions are regarded as fatal for the JVM
 								if (t instanceof OutOfMemoryError && abortIfOutOfMemory) {
@@ -267,7 +275,7 @@ class LoadTestRunner {
 
 
 					private void reportFailure(long failureNum, ByteArrayOutputStream capturedOutput,
-							AdaptorInterface test, final SuiteData suite, final int threadNum) {
+							AdaptorInterface test, final SuiteData suite, final int threadNum) throws MauveTestFailureException {
 						if (reportFailureLimit == -1 || failureNum <= reportFailureLimit) {
 							logger.error("Test failed"
 								+ "\n  Failure num.  = " + failureNum
@@ -278,6 +286,7 @@ class LoadTestRunner {
 								+ "\n>>> Captured test output >>>\n"
 								+ capturedOutput.toString().trim()
 								+ "\n<<<\n");
+							throw new MauveTestFailureException(capturedOutput.toString().trim()); 
 						} else {
 							logger.error("Test failed. Details recorded in execution log.");
 						}

--- a/stf.load/src/stf.load/net/adoptopenjdk/loadTest/MauveTestFailureException.java
+++ b/stf.load/src/stf.load/net/adoptopenjdk/loadTest/MauveTestFailureException.java
@@ -1,0 +1,24 @@
+/*******************************************************************************
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+package net.adoptopenjdk.loadTest;
+
+public class MauveTestFailureException extends Exception {
+	
+	private static final long serialVersionUID = 1L;
+	
+	public MauveTestFailureException(String errMessage) {
+		super(errMessage);
+	}
+}


### PR DESCRIPTION
- Throw exception when Mauve tests fail so it can be used in -Xdump
- Related to  https://github.com/AdoptOpenJDK/stf/issues/81
Signed-off-by: Mesbah_Alam@ca.ibm.com <Mesbah_Alam@ca.ibm.com>