### PR TITLE
Throw MauveTestFailureException in ExecutionTracker if a test fails

### DIFF
--- a/stf.load/src/stf.load/net/adoptopenjdk/loadTest/LoadTestRunner.java
+++ b/stf.load/src/stf.load/net/adoptopenjdk/loadTest/LoadTestRunner.java
@@ -211,11 +211,7 @@ class LoadTestRunner {
 									FirstFailureDumper.instance().createDumpIfFirstFailure((LoadTestBase) test, dumpRequested);
 									
 									// Get log4j to report the test failure
-									try {
-										reportFailure(failureNum, executionTracker.getCapturedOutput(), test, suite, threadNum);
-									} catch (MauveTestFailureException e) {
-										throw e;
-									}
+									reportFailure(failureNum, executionTracker.getCapturedOutput(), test, suite, threadNum);
 								}
 								
 								// Inter test thinking time
@@ -246,11 +242,7 @@ class LoadTestRunner {
 								FirstFailureDumper.instance().createDumpIfFirstFailure((LoadTestBase) test, dumpRequested);
 								
 								// Report exception to process output
-								try { 
-									reportFailure(failureNum, executionTracker.getCapturedOutput(), test, suite, threadNum);
-								} catch (MauveTestFailureException e) {
-									e.printStackTrace();
-								}
+								reportFailure(failureNum, executionTracker.getCapturedOutput(), test, suite, threadNum);
 								
 								// Out of memory exceptions are regarded as fatal for the JVM
 								if (t instanceof OutOfMemoryError && abortIfOutOfMemory) {
@@ -275,7 +267,7 @@ class LoadTestRunner {
 
 
 					private void reportFailure(long failureNum, ByteArrayOutputStream capturedOutput,
-							AdaptorInterface test, final SuiteData suite, final int threadNum) throws MauveTestFailureException {
+							AdaptorInterface test, final SuiteData suite, final int threadNum) {
 						if (reportFailureLimit == -1 || failureNum <= reportFailureLimit) {
 							logger.error("Test failed"
 								+ "\n  Failure num.  = " + failureNum
@@ -286,7 +278,6 @@ class LoadTestRunner {
 								+ "\n>>> Captured test output >>>\n"
 								+ capturedOutput.toString().trim()
 								+ "\n<<<\n");
-							throw new MauveTestFailureException(capturedOutput.toString().trim()); 
 						} else {
 							logger.error("Test failed. Details recorded in execution log.");
 						}

--- a/stf.load/src/stf.load/net/adoptopenjdk/loadTest/reporting/ExecutionTracker.java
+++ b/stf.load/src/stf.load/net/adoptopenjdk/loadTest/reporting/ExecutionTracker.java
@@ -17,6 +17,7 @@ package net.adoptopenjdk.loadTest.reporting;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 
+import net.adoptopenjdk.loadTest.reporting.MauveTestFailureException;
 import net.adoptopenjdk.loadTest.adaptors.AdaptorInterface;
 import net.adoptopenjdk.loadTest.adaptors.AdaptorInterface.ResultStatus;
 import net.adoptopenjdk.loadTest.reporting.ExecutionRecord.Action;
@@ -87,7 +88,7 @@ public class ExecutionTracker {
 	}
 	
 	
-	public synchronized void checkTestOutput(byte[] buff, int off, int len) {
+	public synchronized void checkTestOutput(byte[] buff, int off, int len) throws MauveTestFailureException {
 		// Store this piece of output, incase the test fails and it's needed for debugging
 		outputCapture.write(buff, off, len);
 		
@@ -96,6 +97,9 @@ public class ExecutionTracker {
 		
 		// Update result state
 		testResult = determineNewStatus(testResult, outputScanResult);
+		if (!testResult.testPassed()) {
+			throw new MauveTestFailureException("Mauve test failure detected"); 
+		}
 	}
 
 	

--- a/stf.load/src/stf.load/net/adoptopenjdk/loadTest/reporting/MauveTestFailureException.java
+++ b/stf.load/src/stf.load/net/adoptopenjdk/loadTest/reporting/MauveTestFailureException.java
@@ -12,7 +12,7 @@
 * limitations under the License.
 *******************************************************************************/
 
-package net.adoptopenjdk.loadTest;
+package net.adoptopenjdk.loadTest.reporting;
 
 public class MauveTestFailureException extends Exception {
 	

--- a/stf.load/src/stf.load/net/adoptopenjdk/loadTest/reporting/OutputFilter.java
+++ b/stf.load/src/stf.load/net/adoptopenjdk/loadTest/reporting/OutputFilter.java
@@ -53,8 +53,12 @@ public class OutputFilter extends PrintStream {
 		ExecutionTracker executionTracker = ExecutionTracker.instance();
 
 		if (executionTracker.isRunningTest()) {
-			// Allow the test adaptor to examine the output, and decide if test is passing/failing
-			executionTracker.checkTestOutput(buf, off, len);
+			try {
+				// Allow the test adaptor to examine the output, and decide if test is passing/failing
+				executionTracker.checkTestOutput(buf, off, len);
+			} catch (MauveTestFailureException e) {
+				e.printStackTrace();
+			}
 
 			if (echoToOriginal) {
 				// Write to the original stdout/stderr


### PR DESCRIPTION
- Throw MauveTestFailureException in ExecutionTracker if a test fails

Related to : https://github.com/eclipse/openj9/issues/8204#issuecomment-655086459

Signed-off-by: Mesbah_Alam@ca.ibm.com <Mesbah_Alam@ca.ibm.com>