### PR TITLE
Remove call to printStackTrace() for MauveTestFailureException

### DIFF
--- a/stf.load/src/stf.load/net/adoptopenjdk/loadTest/reporting/OutputFilter.java
+++ b/stf.load/src/stf.load/net/adoptopenjdk/loadTest/reporting/OutputFilter.java
@@ -56,9 +56,7 @@ public class OutputFilter extends PrintStream {
 			try {
 				// Allow the test adaptor to examine the output, and decide if test is passing/failing
 				executionTracker.checkTestOutput(buf, off, len);
-			} catch (MauveTestFailureException e) {
-				e.printStackTrace();
-			}
+			} catch (MauveTestFailureException e) {}
 
 			if (echoToOriginal) {
 				// Write to the original stdout/stderr


### PR DESCRIPTION
Related to https://github.com/AdoptOpenJDK/stf/pull/83#discussion_r455165072
Signed-off-by: Mesbah_Alam@ca.ibm.com <Mesbah_Alam@ca.ibm.com>