### PR TITLE
Added STF method to get simple name for current platform

### DIFF
--- a/stf.core/src/stf.core/net/adoptopenjdk/stf/environment/PlatformFinder.java
+++ b/stf.core/src/stf.core/net/adoptopenjdk/stf/environment/PlatformFinder.java
@@ -137,6 +137,10 @@ public class PlatformFinder {
     	PlatformFinder pf = getInstance();
         return pf.osShortName + "_" + pf.osArch + pf.osEndian + "-" + pf.osArchType;     	     	 
     }
+    
+    public static String getPlatformSimple() throws StfException {
+    	return calcOSShortName();
+    }
 
 	public static Platform getPlatform() throws StfException {
 		return PlatformFinder.getInstance().platform;

--- a/stf.core/src/stf.core/net/adoptopenjdk/stf/environment/StfEnvironmentCore.java
+++ b/stf.core/src/stf.core/net/adoptopenjdk/stf/environment/StfEnvironmentCore.java
@@ -398,6 +398,10 @@ public class StfEnvironmentCore {
 	public String getPlatform() throws StfException {
 		return PlatformFinder.getPlatformAsString();  //TODO: convert to enumeration
 	}
+	
+	public String getPlatformSimple() throws StfException {
+		return PlatformFinder.getPlatformSimple();
+	}
 
 	
 	/** 

--- a/stf.core/src/stf.core/net/adoptopenjdk/stf/extensions/core/StfEnvironment.java
+++ b/stf.core/src/stf.core/net/adoptopenjdk/stf/extensions/core/StfEnvironment.java
@@ -170,7 +170,6 @@ public class StfEnvironment {
 	public FileRef createFileRef(String fileName) throws StfException {
 		return environmentCore.createFileRef(fileName);
 	}
-
 	
 	/**
 	 * @return a string containing the platform name, eg 'linux_x86-64'
@@ -178,6 +177,14 @@ public class StfEnvironment {
 	 */
 	public String getPlatform() throws StfException {
 		return environmentCore.getPlatform();
+	}
+	
+	/**
+	 * @return a simple name for platform e.g. win, osx, zos etc
+	 * @throws StfException if there was a problem interpreting the current platform.
+	 */
+	public String getPlatformSimple() throws StfException {
+		return environmentCore.getPlatformSimple();
 	}
 	
 	/**


### PR DESCRIPTION
- This PR adds an STF helper method for tests to retrieve simple names for current platform. 
Note: Since we removed dependency of PLATFORM env variable in systemtest native makefiles, the makefiles now use simple platform values that they figure out using `uname`. Those simple names are then used to construct paths in which natives are generated. This change in STF is needed to construct the corresponding paths inside test Java code.  

Related to : https://github.com/AdoptOpenJDK/openjdk-systemtest/issues/413

Signed-off-by: Mesbah_Alam@ca.ibm.com <Mesbah_Alam@ca.ibm.com>