### PR TITLE
Add Sparc Support

### DIFF
--- a/stf.core/scripts/stf/stfUtility.pm
+++ b/stf.core/scripts/stf/stfUtility.pm
@@ -227,7 +227,7 @@ sub getPlatform {
 		return "osx";
 	}
 	elsif ($^O =~ 'solaris') {
-		return "solaris";
+		return "sunos";
 	} elsif ($^O =~ 'bsd') {
 		return "bsd";
 	}

--- a/stf.core/scripts/stf/stfUtility.pm
+++ b/stf.core/scripts/stf/stfUtility.pm
@@ -245,7 +245,7 @@ sub getPlatform {
 #  my $platform = stf::stfUtility->getPlatformArch;
 #
 # Returns:
-#  x86, ppc, ppcle, 390, arm or riscv
+#  x86, ppc, ppcle, 390, arm, riscv or sparc
 #------------------------------------------------------------#
 sub getPlatformArch {
 	my $platform = stf::stfUtility->getPlatform;
@@ -271,6 +271,9 @@ sub getPlatformArch {
 		}
 		elsif ($Config{archname} =~ 'riscv') {
 			return "riscv";
+		}
+		elsif ($Config{archname} =~ 'sparc') {
+			return "sparc";
 		}
 		else {
 			die "Platform arch $Config{archname} is not yet supported";
@@ -1236,6 +1239,9 @@ sub parseJavaVersionInfo {
 		elsif ( $Config{archname} =~ /arm/  ) {
 			$arch = 'r';
 		}
+		elsif ( $Config{archname} =~ /sparc/  ) {
+			$arch = 'q';
+		}
 		else {
 		    print "Logging\n";
 			stf::stfUtility->logMsg ( message => "stf::stfUtility->parseJavaVersionInfo: add code for Oracle java running on archname " . $Config{archname} );
@@ -1259,6 +1265,7 @@ sub parseJavaVersionInfo {
 	if ( $arch eq 'p' ) { $java_platform .= 'ppc-'; }
 	if ( $arch eq 'r' ) { $java_platform .= 'arm-'; }
 	if ( $arch eq 'v' ) { $java_platform .= 'riscv-'; }
+	if ( $arch eq 'q' ) { $java_platform .= 'sparc-'; }
 	if ( $arch eq 'z' ) { $java_platform .= '390-'; }
 	if ( $java_platform ne 'Unknown' ) {
 		$java_platform .= $bits;

--- a/stf.core/src/stf.core/net/adoptopenjdk/stf/environment/PlatformFinder.java
+++ b/stf.core/src/stf.core/net/adoptopenjdk/stf/environment/PlatformFinder.java
@@ -86,7 +86,7 @@ public class PlatformFinder {
 		}
 
 		// Validate the architecture value
-		String osArchRegex = "390|x86|ppc|x86|arm|riscv";
+		String osArchRegex = "390|x86|ppc|x86|arm|riscv|sparcv9";
 		if (!osArch.matches(osArchRegex)) {
 			throw new StfException("Unknown architecture value: '" + osArch + "'. Expected one of '" + osArchRegex + "'");
 		}
@@ -225,6 +225,9 @@ public class PlatformFinder {
         } else if(osArch.contains("riscv")) {
             // The openj9 jdk sets os.arch to riscv, the bisheng jdk sets it to riscv64
             osArch = "riscv";
+        } else if(osArch.contains("sparcv9")) {
+            // if the current system is sparcv9 use sparc as the osArch
+            osArch = "sparc";
         } else if (osArch.length() == 4
         	 && osArch.charAt(0) == 'i'
         	 && Character.isDigit(osArch.charAt(1))

--- a/stf.core/src/stf.core/net/adoptopenjdk/stf/environment/PlatformFinder.java
+++ b/stf.core/src/stf.core/net/adoptopenjdk/stf/environment/PlatformFinder.java
@@ -86,7 +86,7 @@ public class PlatformFinder {
 		}
 
 		// Validate the architecture value
-		String osArchRegex = "390|x86|ppc|x86|arm|riscv|sparcv9";
+		String osArchRegex = "390|x86|ppc|x86|arm|riscv|sparc";
 		if (!osArch.matches(osArchRegex)) {
 			throw new StfException("Unknown architecture value: '" + osArch + "'. Expected one of '" + osArchRegex + "'");
 		}

--- a/stf.core/src/stf.core/net/adoptopenjdk/stf/environment/PlatformFinder.java
+++ b/stf.core/src/stf.core/net/adoptopenjdk/stf/environment/PlatformFinder.java
@@ -34,7 +34,7 @@ public class PlatformFinder {
 		ZOS("zos"),
 		BSD("bsd"),
 		OSX("osx"),
-		SOLARIS("solaris");
+		SOLARIS("sunos");
 		
 		private String shortName;
 		private Platform(String shortName) { this.shortName = shortName; }

--- a/stf.core/src/stf.core/net/adoptopenjdk/stf/environment/PlatformFinder.java
+++ b/stf.core/src/stf.core/net/adoptopenjdk/stf/environment/PlatformFinder.java
@@ -195,9 +195,9 @@ public class PlatformFinder {
             osShortName = "bsd";
         }
         
-        // if we are on sunos use solaris as the shortname
+        // if we are on sunos use sunos as the shortname
         if (osName.contains("sunos")) {
-            osShortName = "solaris";
+            osShortName = "sunos";
         }
                 
         return osShortName;

--- a/stf.core/src/stf.core/net/adoptopenjdk/stf/environment/StfEnvironmentCore.java
+++ b/stf.core/src/stf.core/net/adoptopenjdk/stf/environment/StfEnvironmentCore.java
@@ -415,7 +415,7 @@ public class StfEnvironmentCore {
 		case LINUX:   return "linux";
 		case ZOS :    return "zos";
 		case OSX :    return "macosx";
-		case SOLARIS :    return "solaris";
+		case SOLARIS :    return "sunos";
 		default:      throw new StfException("Unknown platform for osgi.os: " + PlatformFinder.getPlatformAsString());
 		}
 	}
@@ -453,6 +453,9 @@ public class StfEnvironmentCore {
 			return "arm";
 		} else if (archName.equals("riscv")) {
 			return "riscv";
+		}
+		} else if (archName.equals("sparc")) {
+			return "sparc";
 		}
 		
 		throw new StfException("Unknown osgi.arch. archName:" + archName + " wordSize:" + wordSize);

--- a/stf.core/src/stf.core/net/adoptopenjdk/stf/environment/StfEnvironmentCore.java
+++ b/stf.core/src/stf.core/net/adoptopenjdk/stf/environment/StfEnvironmentCore.java
@@ -415,7 +415,7 @@ public class StfEnvironmentCore {
 		case LINUX:   return "linux";
 		case ZOS :    return "zos";
 		case OSX :    return "macosx";
-		case SOLARIS :    return "sunos";
+		case SOLARIS :    return "solaris";
 		default:      throw new StfException("Unknown platform for osgi.os: " + PlatformFinder.getPlatformAsString());
 		}
 	}

--- a/stf.core/src/stf.core/net/adoptopenjdk/stf/environment/StfEnvironmentCore.java
+++ b/stf.core/src/stf.core/net/adoptopenjdk/stf/environment/StfEnvironmentCore.java
@@ -453,7 +453,6 @@ public class StfEnvironmentCore {
 			return "arm";
 		} else if (archName.equals("riscv")) {
 			return "riscv";
-		}
 		} else if (archName.equals("sparc")) {
 			return "sparc";
 		}


### PR DESCRIPTION
fixes: 

```bash
11:21:29  GEN stderr Exception in thread "main" java.lang.IllegalStateException: Failed to get property: stf-bin-dir
11:21:29  GEN stderr 	at net.adoptopenjdk.stf.environment.properties.OrderedProperties.getProperty(OrderedProperties.java:105)
11:21:29  GEN stderr 	at net.adoptopenjdk.stf.environment.properties.LayeredProperties.resolveProperty(LayeredProperties.java:112)
11:21:29  GEN stderr 	at net.adoptopenjdk.stf.environment.properties.LayeredProperties.getProperty(LayeredProperties.java:73)
11:21:29  GEN stderr 	at net.adoptopenjdk.stf.environment.StfEnvironmentCore.getProperty(StfEnvironmentCore.java:352)
11:21:29  GEN stderr 	at net.adoptopenjdk.stf.environment.StfEnvironmentCore.createDirectoryRefFromProperty(StfEnvironmentCore.java:290)
11:21:29  GEN stderr 	at net.adoptopenjdk.stf.environment.StfEnvironmentCore.<init>(StfEnvironmentCore.java:85)
11:21:29  GEN stderr 	at net.adoptopenjdk.stf.runner.StfRunner.executeTest(StfRunner.java:140)
11:21:29  GEN stderr 	at net.adoptopenjdk.stf.runner.StfRunner.main(StfRunner.java:69)
11:21:29  GEN stderr Caused by: net.adoptopenjdk.stf.StfException: Unknown architecture value: 'sparcv9'. Expected one of '390|x86|ppc|x86|arm|riscv'
```