### PR TITLE
Remove check that Java version output must start with "java version"

### DIFF
--- a/stf.core/src/stf.core/net/adoptopenjdk/stf/environment/JavaVersion.java
+++ b/stf.core/src/stf.core/net/adoptopenjdk/stf/environment/JavaVersion.java
@@ -96,11 +96,6 @@ public class JavaVersion {
         if (javaVersionOutput.startsWith("openjdk version")) {
         	javaVersionOutput = javaVersionOutput.replace("openjdk", "java");
         }
-
-        // Sanity check. Verify that the output appears correct
-		if (!javaVersionOutput.startsWith("java version")) {
-			throw new StfException("'Java -version' output does not start with 'java version'. Actual output was: " + javaVersionOutput);
-		}
 	}
 
 	public static JavaVersion getInstance(StfEnvironmentCore environmentCore) throws StfException {
@@ -225,7 +220,7 @@ public class JavaVersion {
 		if (version == 9) {
 			return isJava9();
 		}
-		return javaVersionOutput.trim().startsWith(brand + " version \"" + stringifiedVersion);
+		return javaVersionOutput.contains("version \"" + stringifiedVersion);
 	}
 
 	/**


### PR DESCRIPTION
- This PR removes the check for Java version output from JavaVersion.java class from STF. 

- Background: We do not need to check for java version output's validity in STF, since we have functional tests to check for it and also perform additional tests for it in TKG. Besides, this check over here causes exceptions every time we want to test a new SDK (e.g.  https://github.com/eclipse-openj9/openj9/issues/13154). 

- Note : This PR is part of a larger [task](https://github.com/adoptium/STF/issues/114) of re-implementing how STF figures out Java version - which requires that we first investigate how Java version is used in various STF based tests. We will cover that in a separate PR. 

- Fixes https://github.com/eclipse-openj9/openj9/issues/13154

Signed-off-by: Mesbah-Alam <Mesbah_Alam@ca.ibm.com>