### PR TITLE
Correct URLs for STF repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 This repository contains the System Test Framework (STF) used by test cases in the javasvt repository to execute multi process, multi step Java tests.
 
-[Quick start (Unix)](#unix)  
-[Quick start (Windows)](#windows)  
+[Quick start (Unix)](#unix)
+[Quick start (Windows)](#windows)
 [More documentation](stf.build/docs/build.md)
 
 <a name="unix"></a>
@@ -17,14 +17,13 @@ wget is only required for the make configure step, which only needs to be done o
 
 Either copy, paste and execute [this script](stf.build/scripts/stf_clone_make.sh) which runs the command below, or run the commands yourself.
 
-
 ```shell
 # 1. Create a directory for the git clone
 mkdir -p $HOME/git
 
 # 2. Clone the git repository
 cd $HOME/git
-git clone https://github.com/AdoptOpenJDK/stf.git stf
+git clone https://github.com/adoptium/STF.git stf
 
 # 3. Set JAVA_HOME to a Java 8 or later Java
 
@@ -62,7 +61,7 @@ mkdir c:\%USERPROFILE%\git
 
 REM 2. Clone the test cases
 cd c:\%USERPROFILE%\git
-git clone https://github.com/AdoptOpenJDK/stf.git stf
+git clone https://github.com/adoptium/STF.git stf
 
 REM 3. Set JAVA_HOME to a Java 8 or later Java
 SET JAVA_HOME=<java-home>

--- a/stf.build/docs/build.md
+++ b/stf.build/docs/build.md
@@ -18,7 +18,7 @@ These prereqs must be installed before attempting to build STF
 ### Installing the prereqs using the build scripts
 1. An internet connection is required
 2. Review the list of prereqs listed under 'Installing prereqs manually' and confirm that you accept their license terms.
-3. `git clone https://github.com/adoptium/stf.git stf`
+3. `git clone https://github.com/adoptium/STF.git stf`
 4. Change into the stf.build directory `cd <git-root>;stf.build`
 5. `make configure`
 
@@ -36,7 +36,7 @@ These prereqs must be installed before attempting to build STF
 | wget                  | https://www.gnu.org/copyleft/gpl.html                         | stf.build  | Windows - download from https://sourceforge.net/projects/gnuwin32/files/wget/1.11.4-1/wget-1.11.4-1-bin.zip                                                                                                                                                                   | Add to PATH                                                                                                                                                                                                                                                           | No                                 |
 
 ## Building from a command line
-1. `git clone https://github.com/adoptium/stf.git stf`
+1. `git clone https://github.com/adoptium/STF.git stf`
 2. Change into the stf.build directory `cd <git-root>;stf.build`
 3. `make`
 
@@ -53,6 +53,6 @@ line arguments when the tests execute outside of Eclipse.
 - Select the directory containing the prereqs. Select import into the new systemtest_prereqs folder.  Do not tick
 the 'Create top level folder' check box (otherwise you get an extra 'systemtest_prereqs' folder which you do not
 want).
-3. `git clone https://github.com/adoptium/stf.git stf`
+3. `git clone https://github.com/adoptium/STF.git stf`
 4. Import the STF projects into Eclipse (Find and import Eclipse projects)
 5. Eclipse should now build the projects without errors (check the 'Problems' view).

--- a/stf.build/scripts/stf_clone_make.bat
+++ b/stf.build/scripts/stf_clone_make.bat
@@ -13,7 +13,7 @@ REM limitations under the License.
 REM Save current directory
 set currdir=%cd%
 REM Clone
-(IF NOT EXIST %USERPROFILE%\git mkdir %USERPROFILE%\git) && cd %USERPROFILE%\git && (IF EXIST stf rmdir /s /q stf) && git clone https://github.com/adoptium/stf.git stf
+(IF NOT EXIST %USERPROFILE%\git mkdir %USERPROFILE%\git) && cd %USERPROFILE%\git && (IF EXIST stf rmdir /s /q stf) && git clone https://github.com/adoptium/STF.git stf
 REM Configure (get prereqs)
 cd %USERPROFILE%\git\stf\stf.build
 make configure

--- a/stf.build/scripts/stf_clone_make.sh
+++ b/stf.build/scripts/stf_clone_make.sh
@@ -14,7 +14,7 @@
 #-------------------------------------------------------------------------
 
 # Clone
-mkdir -p $HOME/git && cd $HOME/git && rm -rf stf && mkdir stf && git clone https://github.com/adoptium/stf.git stf
+mkdir -p $HOME/git && cd $HOME/git && rm -rf stf && mkdir stf && git clone https://github.com/adoptium/STF.git stf
 if [ "$?" != "0" ]; then
         echo "Error cloning stf" 1>&2
         exit 1


### PR DESCRIPTION
The URL ends with `STF.git`, not `stf.git` (and is in the `adoptium` organization).

