### PR TITLE
do not process stdderr when running df

### DIFF
--- a/stf.core/scripts/stf.pl
+++ b/stf.core/scripts/stf.pl
@@ -733,11 +733,10 @@ sub check_free_space {
 	my @df_output = ();
 	print "Retrieving amount of free space on drive containing " .  $results_root . "\n";
 	if ($^O eq 'MSWin32') {
-		# dir doesn't work with forward slashes or escaped backslashes, so remove any that are there.
-		$results_root =~ s,/,\\,g;
-		$results_root =~ s,\\\\,\\,g;
-		$cmd = "cmd /c dir $results_root";
-		@df_output = `$cmd 2>&1`;
+		# dir doesn't work with escaped backslashes, so remove any that are there.
+		$results_root =~ s/\\\\/\\/g;
+		$cmd = "dir $results_root";
+		@df_output = `$cmd`;
 		foreach my $line ( @df_output ) {
 			if ( $line =~ m/.*bytes\s+free.*/ ) {
 				#               3 Dir(s)  214,264,049,664 bytes free


### PR DESCRIPTION
Fixes https://github.com/adoptium/infrastructure/issues/2508

This does mean stderr is likely to come out to the console somewhere, which is fine as I don't think the code looks explicitly for potential error messages. I don't believe any `df` command on any OS will be sending the "real" data to `stderr` so this fix should be fine everywhere.

Signed-off-by: Stewart X Addison <sxa@redhat.com>