### PR TITLE
Make sure java_home is set before we check-for-tools-jar

### DIFF
--- a/stf.build/include/top.xml
+++ b/stf.build/include/top.xml
@@ -302,17 +302,17 @@ limitations under the License.
 		Note: In Java 9 the classes we need from tools.jar were folded into the Class Library, 
 		so we don't need the jar, and this is correct.
 	-->
-	<target name="check-for-tools-jar">
+	<target name="check-for-tools-jar" depends="setup-java-properties">
 		<property name="tools_jar_dir" location="${first_prereqs_root}/tools"/>
 		<property name="tools_jar_file" value="tools.jar"/>
-		<echo message="java.specification.version is ${java.specification.version}"/>
+		<echo message="java_java_specification_version is ${java_java_specification_version}"/>
 		<condition property="tools_jar_correct">
 			<or>
 				<not>
-					<equals arg1="${java.specification.version}" arg2="1.8"/>
+					<equals arg1="${java_java_specification_version}" arg2="1.8"/>
 				</not>
 				<and>
-					<equals arg1="${java.specification.version}" arg2="1.8"/>
+					<equals arg1="${java_java_specification_version}" arg2="1.8"/>
 					<available file="${tools_jar_dir}/${tools_jar_file}"/>
 				</and>
 			</or>


### PR DESCRIPTION
- Invoke `setup-java-properties` target to setup java_home to be used (in case of getDependency build, we are passing in a jdk8 sdk via `-Djava.home` into the Ant configure script). 
- To avoid confusion, use `java_java_specification_version` to check java version to determine if tools.jar is needed (only needed for jdk8). This is especially relevant for getDependency build where JAVA_HOME is not setup by TKG. 

Resolves backlog/issues/1066