### PR TITLE
Use tools.jar from java.home lib

### DIFF
--- a/stf.build/include/top.xml
+++ b/stf.build/include/top.xml
@@ -132,7 +132,7 @@ limitations under the License.
 		<pathelement location="${first_prereqs_root}/log4j/log4j-core.jar"/>
 	</path>
 	<path id="tools.class.path">
-		<pathelement location="${first_prereqs_root}/tools/tools.jar"/>
+		<pathelement location="${java.home}/../lib/tools.jar"/>
 	</path>
 	<path id="asm.class.path">
 		<pathelement location="${first_prereqs_root}/asm/asm.jar"/>
@@ -332,9 +332,9 @@ limitations under the License.
 	-->
 
 	<target name="configure-tools-jar" depends="setup-java-properties" unless="${tools_jar_correct}">
-		<property name="tools_jar_origin" value="${java_bindir}/../lib/tools.jar"/>
+		<property name="tools_jar_origin" value="${java.home}/../lib/tools.jar"/>
 		<echo message="configure-tools-jar: Copying ${tools_jar_origin} to ${tools_jar_dir}"/>
-		<copy file="${tools_jar_origin}" todir="${tools_jar_dir}"/>
+        <copy file="${tools_jar_origin}" todir="${tools_jar_dir}"/>
 		<property name="tools_jar" value="${tools_jar_dir}/${tools_jar_file}"/>
 		<available file="${tools_jar_dir}/${tools_jar_file}" property="tools_jar_correct"/>
 	</target>

--- a/stf.core/src/stf.core/net/adoptopenjdk/stf/environment/StfEnvironmentCore.java
+++ b/stf.core/src/stf.core/net/adoptopenjdk/stf/environment/StfEnvironmentCore.java
@@ -94,6 +94,18 @@ public class StfEnvironmentCore {
 			this.testRoots.add(defaultTestRoot);
 			invocationProperties.put(Stf.ARG_TEST_ROOT.getName(), defaultTestRoot.getSpec());
 		}
+
+		try {
+			String javaHome = System.getProperty("java.home");
+			File javaLibDir = new File(javaHome, "../lib");
+			if (javaLibDir.exists() && javaLibDir.isDirectory()) {
+				this.testRoots.add(new DirectoryRef(javaLibDir.getCanonicalPath()));
+			} else {
+				System.out.println("Java lib directory does not exist: " + javaLibDir.getCanonicalPath());
+			}
+		} catch (IOException e) {
+			throw new RuntimeException("Failed to add Java lib directory to test roots", e);
+		}
 		
 		// Work out where the prereqs are
 		if (!getProperty(Stf.ARG_SYSTEMTEST_PREREQS).isEmpty()) {


### PR DESCRIPTION
This PR use `tools.jar` from the `java.home/lib` directory.
Related changes in other repositories:
- **aqa-tests**: Updated to use JDK 17 (instead of JDK 8) to build system test-related jars (https://github.com/adoptium/aqa-tests/pull/5711).
- **TKG**: Removed the tools.jar dependency ([adoptium/TKG#633](https://github.com/adoptium/TKG/pull/633)).

related: [eclipse-openj9/openj9#19888](https://github.com/eclipse-openj9/openj9/issues/19888)