### PR TITLE
Add Visual Studio 2022 vcvarsall.bat path

### DIFF
--- a/stf.build/include/top.xml
+++ b/stf.build/include/top.xml
@@ -105,12 +105,17 @@ limitations under the License.
 		<available file="${vs14_vcvarsall_filename}" property="vs14_available"/>
 		<property name="vs10_vcvarsall_filename" location="c:\\Program Files (x86)\\Microsoft Visual Studio 10.0\\VC\\vcvarsall.bat"/>
 		<available file="${vs10_vcvarsall_filename}" property="vs10_available"/>
+		<property name="vs22_pro_vcvarsall_filename" location="c:\\Program Files\\Microsoft Visual Studio\\2022\\Professional\\VC\\Auxiliary\\Build\\vcvarsall.bat"/>
+	   	<available file="${vs22_pro_vcvarsall_filename}" property="vs22_pro_available"/>
 		<condition property="vcvarsall_filename" value="${vs14_vcvarsall_filename}">
 			<isset property="vs14_available"/>
 		</condition>
 		<condition property="vcvarsall_filename" value="${vs10_vcvarsall_filename}">
 			<isset property="vs10_available"/>
 		</condition>
+		<condition property="vcvarsall_filename" value="${vs22_pro_vcvarsall_filename}">
+			<isset property="vs22_pro_available"/>
+	    	</condition>
 		<condition property="windows_native_compiler_present" value="true">
 			<isset property="vcvarsall_filename"/>
 			</condition>


### PR DESCRIPTION
Root cause : 
Windows 2025 machines has visual studio 2022 But VS2022 vcvarsall.bat path was not configured in STF  top.xml  hence generating sharedClasses.dll got affected and lead to  below error.

[Error Log :](https://trssrtp1.fyre.ibm.com/output/test?id=678ce99b1a07b663f71f38da)
SharedClassesAPI_1 : Test_openjdk11_j9_extended.system_x86-64_windows_testList_0/jvmtest/system/openj9-systemtest/openj9.test.sharedClasses.jvmti/bin/native/win/sharedClasses.dll could not be opened (The specified module could not be found. )

Fix: Added Visual Studio 2022 vcvarsall.bat path  in STF top.xml
Issue  reference: https://github.ibm.com/runtimes/automation/issues/183
Log: https://hyc-runtimes-jenkins.swg-devops.com/job/Grinder/47236/consoleFull
