### PR TITLE
Echo os.name in platform-properties

### DIFF
--- a/stf.build/include/top.xml
+++ b/stf.build/include/top.xml
@@ -537,7 +537,7 @@ limitations under the License.
 			<delete file="${properties_file}" verbose="false"/>
 			<property name="resolved.os.name" value="${@{java.id}.os.name}"/>
 			<echo message="DEBUG: Resolved os.name for @{java.id} is ${resolved.os.name}"/>
-			<get-platform-prefix property="@{osname.property}" osname="${@{java.id}.os.name}"/>
+			<get-platform-prefix property="@{osname.property}" osname="${resolved.os.name}"/>
 			<get-platform-arch property="@{arch.property}" arch="${@{java.id}.os.arch}"/>
 			<get-platform-bits property="@{bits.property}" bits="${@{java.id}.sun.arch.data.model}"/>
 			<property name="@{platform.property}" value="${@{osname.property}}_${@{arch.property}}-${@{bits.property}}"/>

--- a/stf.build/include/top.xml
+++ b/stf.build/include/top.xml
@@ -535,6 +535,8 @@ limitations under the License.
 				</propertyset>
 			</echoproperties>
 			<delete file="${properties_file}" verbose="false"/>
+            <property name="resolved.os.name" value="${@{java.id}.os.name}"/>
+            <echo message="DEBUG: Resolved os.name for @{java.id} is ${resolved.os.name}"/>
 			<get-platform-prefix property="@{osname.property}" osname="${@{java.id}.os.name}"/>
 			<get-platform-arch property="@{arch.property}" arch="${@{java.id}.os.arch}"/>
 			<get-platform-bits property="@{bits.property}" bits="${@{java.id}.sun.arch.data.model}"/>

--- a/stf.build/include/top.xml
+++ b/stf.build/include/top.xml
@@ -535,8 +535,8 @@ limitations under the License.
 				</propertyset>
 			</echoproperties>
 			<delete file="${properties_file}" verbose="false"/>
-            <property name="resolved.os.name" value="${@{java.id}.os.name}"/>
-            <echo message="DEBUG: Resolved os.name for @{java.id} is ${resolved.os.name}"/>
+			<property name="resolved.os.name" value="${@{java.id}.os.name}"/>
+			<echo message="DEBUG: Resolved os.name for @{java.id} is ${resolved.os.name}"/>
 			<get-platform-prefix property="@{osname.property}" osname="${@{java.id}.os.name}"/>
 			<get-platform-arch property="@{arch.property}" arch="${@{java.id}.os.arch}"/>
 			<get-platform-bits property="@{bits.property}" bits="${@{java.id}.sun.arch.data.model}"/>


### PR DESCRIPTION
- To debug , echo value of @{java.id}.os.name before passing to get-platform-prefix


related:https://github.com/eclipse-openj9/openj9/issues/18110

Signed-off-by: Anna Babu Palathingal <anna.bp@ibm.com>