### PR TITLE
Use logger.trace() to output the test list inventory data

### DIFF
--- a/stf.load/src/stf.load/net/adoptopenjdk/loadTest/InventoryData.java
+++ b/stf.load/src/stf.load/net/adoptopenjdk/loadTest/InventoryData.java
@@ -108,14 +108,14 @@ public class InventoryData {
 
 		// List the tests to be used
 		if (verbose) {
-			logger.info("Final test list:");
+			logger.trace("Final test list:");
 			String adjustedWeightingString = " ";
 			for (AdaptorInterface test : testList) {
 				if (weightingMultiplier.intValue() > 1) {
 					int roundedWeighting = test.getRoundedAdjustedWeighting(weightingMultiplier);
 					adjustedWeightingString = "->" + roundedWeighting;
 				}
-				logger.info("  " + test.getTestNum() + " " + test + "  Weighting=" + test.getWeighting() + adjustedWeightingString);
+				logger.trace("  " + test.getTestNum() + " " + test + "  Weighting=" + test.getWeighting() + adjustedWeightingString);
 			}
 		}
 	}


### PR DESCRIPTION
Greatly reduce the amount of output from system tests. Afaik we don't need the entire inventory test list printed for every test run.

Grinder MiniMix_J9_5m_0 https://openj9-jenkins.osuosl.org/view/Test/job/Grinder/5157 shows the reduced output.